### PR TITLE
GeoDuckDB: Auto CRS and fix logger

### DIFF
--- a/prompt2map/providers/geoduckdb.py
+++ b/prompt2map/providers/geoduckdb.py
@@ -81,7 +81,7 @@ class GeoDuckDB(GeoDatabase):
             return crs[0][0]
         
         # via Parquet metadata
-        parquet_data = pq.ParquetFile("s3://prompt2map/data/prod/geodata.parquet")
+        parquet_data = pq.ParquetFile(self.file_path)
         metadata = parquet_data.schema_arrow.metadata
         try:
             geo = json.loads(metadata[b'geo'])


### PR DESCRIPTION
## Summary

GeoDuckDB: Auto identify CRS from data source or pass manually and fix logger name

## What type of PR is this?
  - [X] 🍕 New feature
  - [X] 🐛 Bug fix
  - [ ] 📝 Documentation update
  - [ ] 🎨 Style
  - [ ] 👷‍♂️ Code refactor
  - [ ] 🔥 Performance improvements
  - [ ] ✅ Test
  - [ ] 📦 Chore
  - [ ] ⏪ Revert
  - [ ] Other (please describe):

## Description

- in Geoduckdb CRS can be passed via constructor or be obtained dynamically
- Three CRS extractions: via duckdb, via parquet metadata and via geopandas loading
- Fix Geoduckdb class logger name

## Related Issues

N/A

## How Has This Been Tested?

Localhost in jupyter notebook

## Screenshots (if appropriate)

N/A

## Technical Debt

N/A
